### PR TITLE
fixed build Error: .plugins[0][1] must be an object, false, or undefined

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,12 +3,12 @@ module.exports = {
     '@vue/cli-plugin-babel/preset'
   ],
   "plugins": [
-    ["component", [
+    ["component", 
       {
         "libraryName": "mint-ui",
         "style": true
       }
-    ]],
+    ,"mint-ui"],
     ['import', {
       libraryName: 'vant',
       libraryDirectory: 'es',


### PR DESCRIPTION
fixed
```
 ERROR  Failed to compile with 1 errors                                                                                                     1:11:40 PM

 error  in ./src/main.js

Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: .plugins[0][1] must be an object, false, or undefined
```